### PR TITLE
Added Kibana 4.2.0-beta1

### DIFF
--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -1,0 +1,35 @@
+FROM debian:jessie
+
+# add our user and group first to make sure their IDs get assigned consistently
+RUN groupadd -r kibana && useradd -r -m -g kibana kibana
+
+RUN apt-get update && apt-get install -y ca-certificates curl --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+# grab gosu for easy step-down from root
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN arch="$(dpkg --print-architecture)" \
+	&& set -x \
+	&& curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
+
+ENV KIBANA_VERSION 4.2.0-beta1
+ENV KIBANA_SHA1 971a0660ae4a17b935d7f87d6889e1e7185b4562
+
+RUN set -x \
+	&& curl -fSL "https://download.elastic.co/kibana/kibana/kibana-${KIBANA_VERSION}-linux-x64.tar.gz" -o kibana.tar.gz \
+	&& echo "${KIBANA_SHA1}  kibana.tar.gz" | sha1sum -c - \
+	&& mkdir -p /opt/kibana \
+	&& tar -xz --strip-components=1 -C /opt/kibana -f kibana.tar.gz \
+	&& chown -R kibana:kibana /opt/kibana \
+	&& rm kibana.tar.gz
+
+ENV PATH /opt/kibana/bin:$PATH
+
+COPY ./docker-entrypoint.sh /
+
+EXPOSE 5601
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["kibana"]

--- a/4.2/docker-entrypoint.sh
+++ b/4.2/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+# Add kibana as command if needed
+if [[ "$1" == -* ]]; then
+	set -- kibana "$@"
+fi
+
+# Run as user "kibana" if the command is "kibana"
+if [ "$1" = 'kibana' ]; then
+	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
+		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
+		sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 '$ELASTICSEARCH_URL'!" /opt/kibana/config/kibana.yml
+	else
+		echo >&2 'warning: missing ELASTICSEARCH_PORT_9200_TCP or ELASTICSEARCH_URL'
+		echo >&2 '  Did you forget to --link some-elasticsearch:elasticsearch'
+		echo >&2 '  or -e ELASTICSEARCH_URL=http://some-elasticsearch:9200 ?'
+		echo >&2
+	fi
+	
+	set -- gosu kibana "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
The entrypoint script is slightly adjusted for the new configuration file syntax specifying the elasticsearch URL.

Also, a user home directory for the `kibana` user is now mandatory, hence the adjustment of the `useradd` command, and the downloaded tar file has more restrictive file permissions set, which meant the extracted files needed their ownership adjusted.

Requires an [Elasticsearch 2.x](https://github.com/docker-library/elasticsearch/blob/master/2.0/Dockerfile) server to work.
