### PR TITLE
Fix ELASTICSEARCH_URL.

### DIFF
--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -11,7 +11,7 @@ fi
 if [ "$1" = 'kibana' ]; then
 	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
 		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
-		sed -ri "s!^(elasticsearch_url:).*!\1 '$ELASTICSEARCH_URL'!" /opt/kibana/config/kibana.yml
+		sed -ri "s|^(elasticsearch_url:).*|\1 $ELASTICSEARCH_URL|" /opt/kibana/config/kibana.yml
 	else
 		echo >&2 'warning: missing ELASTICSEARCH_PORT_9200_TCP or ELASTICSEARCH_URL'
 		echo >&2 '  Did you forget to --link some-elasticsearch:elasticsearch'

--- a/4.1/docker-entrypoint.sh
+++ b/4.1/docker-entrypoint.sh
@@ -11,7 +11,7 @@ fi
 if [ "$1" = 'kibana' ]; then
 	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
 		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
-		sed -ri "s!^(elasticsearch_url:).*!\1 '$ELASTICSEARCH_URL'!" /opt/kibana/config/kibana.yml
+		sed -ri "s|^(elasticsearch_url:).*|\1 $ELASTICSEARCH_URL|" /opt/kibana/config/kibana.yml
 	else
 		echo >&2 'warning: missing ELASTICSEARCH_PORT_9200_TCP or ELASTICSEARCH_URL'
 		echo >&2 '  Did you forget to --link some-elasticsearch:elasticsearch'


### PR DESCRIPTION
Using 4.0 and 4.1, if I specify ELASTICSEARCH_URL=http://server:port it gets completely ignored, and kibana tries to connect to http://localhost:9200 instead.

The sed expression in docker-entrypoint.sh is broken for a number of reasons.  ! has special meaning, and needs to be in single, not double, quotes.  It's not a great choice of separator for sed anyway, so I've changed to the more reasonable pipe character, which is equally unlikely to cause problems.
Variables need to be in double, not single, quotes, and thus the single quotes around $ELASTICSEARCH_URL would have broken things even without the problems of using !.

I've fixed the various problems with the sed expression, and it works properly now.
