### PR TITLE
Bump to v4.1.2

### DIFF
--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -15,8 +15,8 @@ RUN arch="$(dpkg --print-architecture)" \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-ENV KIBANA_VERSION 4.1.1
-ENV KIBANA_SHA1 d43e039adcea43e1808229b9d55f3eaee6a5edb9
+ENV KIBANA_VERSION 4.1.2
+ENV KIBANA_SHA1 45e67114f7dac4ccac8118bf98ee8f6362c7a6a1
 
 RUN set -x \
 	&& curl -fSL "https://download.elastic.co/kibana/kibana/kibana-${KIBANA_VERSION}-linux-x64.tar.gz" -o kibana.tar.gz \


### PR DESCRIPTION
https://www.elastic.co/blog/kibana-4-1-2-now-available
