### PR TITLE
Added $KIBANA_DEFAULTAPPID variable

### DIFF
--- a/4.2/docker-entrypoint.sh
+++ b/4.2/docker-entrypoint.sh
@@ -9,6 +9,9 @@ fi
 
 # Run as user "kibana" if the command is "kibana"
 if [ "$1" = 'kibana' ]; then
+	if test -n "$KIBANA_DEFAULTAPPID" ; then
+		sed -ri "s!^(\#\s*)?(kibana\.defaultAppId:).*!\2 '$KIBANA_DEFAULTAPPID'!" /opt/kibana/config/kibana.yml
+	fi
 	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
 		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
 		sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 '$ELASTICSEARCH_URL'!" /opt/kibana/config/kibana.yml

--- a/4.2/docker-entrypoint.sh
+++ b/4.2/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # Run as user "kibana" if the command is "kibana"
 if [ "$1" = 'kibana' ]; then
-	if test -n "$KIBANA_DEFAULTAPPID" ; then
+	if [[ "$KIBANA_DEFAULTAPPID" ]]; then
 		sed -ri "s!^(\#\s*)?(kibana\.defaultAppId:).*!\2 '$KIBANA_DEFAULTAPPID'!" /opt/kibana/config/kibana.yml
 	fi
 	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then

--- a/4.3/docker-entrypoint.sh
+++ b/4.3/docker-entrypoint.sh
@@ -9,6 +9,9 @@ fi
 
 # Run as user "kibana" if the command is "kibana"
 if [ "$1" = 'kibana' ]; then
+	if test -n "$KIBANA_DEFAULTAPPID" ; then
+		sed -ri "s!^(\#\s*)?(kibana\.defaultAppId:).*!\2 '$KIBANA_DEFAULTAPPID'!" /opt/kibana/config/kibana.yml
+	fi
 	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
 		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
 		sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 '$ELASTICSEARCH_URL'!" /opt/kibana/config/kibana.yml

--- a/4.3/docker-entrypoint.sh
+++ b/4.3/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # Run as user "kibana" if the command is "kibana"
 if [ "$1" = 'kibana' ]; then
-	if test -n "$KIBANA_DEFAULTAPPID" ; then
+	if [[ "$KIBANA_DEFAULTAPPID" ]]; then
 		sed -ri "s!^(\#\s*)?(kibana\.defaultAppId:).*!\2 '$KIBANA_DEFAULTAPPID'!" /opt/kibana/config/kibana.yml
 	fi
 	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then


### PR DESCRIPTION
1) Save a dashboard as "Default" in Kibana.
2) Add the following environment variable to the Docker run command for
Kibana:
--env="KIBANA_DEFAULTAPPID=dashboard/Default"
3) Kibana will now automatically redirect users to the "Default"
dashboard on startup.
For further details see:
https://www.elastic.co/guide/en/kibana/current/kibana-server-properties.html
This property was added in Kibana 4.2

Fixes #16
