### PR TITLE
Simplify linking

### DIFF
--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -41,11 +41,15 @@ RUN set -x \
 	&& mkdir -p /opt/kibana \
 	&& tar -xz --strip-components=1 -C /opt/kibana -f kibana.tar.gz \
 	&& chown -R kibana:kibana /opt/kibana \
-	&& rm kibana.tar.gz
+	&& rm kibana.tar.gz \
+	\
+# ensure the default configuration is useful when using --link
+	&& sed -ri "s!^(\#\s*)?(elasticsearch_url:).*!\2 'http://elasticsearch:9200'!" /opt/kibana/config/kibana.yml \
+	&& grep -q 'elasticsearch:9200' /opt/kibana/config/kibana.yml
 
 ENV PATH /opt/kibana/bin:$PATH
 
-COPY ./docker-entrypoint.sh /
+COPY docker-entrypoint.sh /
 
 EXPOSE 5601
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 # Add kibana as command if needed
@@ -9,16 +8,10 @@ fi
 
 # Run as user "kibana" if the command is "kibana"
 if [ "$1" = 'kibana' ]; then
-	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
-		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
+	if [ "$ELASTICSEARCH_URL" ]; then
 		sed -ri "s!^(\#\s*)?(elasticsearch_url:).*!\2 '$ELASTICSEARCH_URL'!" /opt/kibana/config/kibana.yml
-	else
-		echo >&2 'warning: missing ELASTICSEARCH_PORT_9200_TCP or ELASTICSEARCH_URL'
-		echo >&2 '  Did you forget to --link some-elasticsearch:elasticsearch'
-		echo >&2 '  or -e ELASTICSEARCH_URL=http://some-elasticsearch:9200 ?'
-		echo >&2
 	fi
-	
+
 	set -- gosu kibana tini -- "$@"
 fi
 

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -41,11 +41,15 @@ RUN set -x \
 	&& mkdir -p /opt/kibana \
 	&& tar -xz --strip-components=1 -C /opt/kibana -f kibana.tar.gz \
 	&& chown -R kibana:kibana /opt/kibana \
-	&& rm kibana.tar.gz
+	&& rm kibana.tar.gz \
+	\
+# ensure the default configuration is useful when using --link
+	&& sed -ri "s!^(\#\s*)?(elasticsearch_url:).*!\2 'http://elasticsearch:9200'!" /opt/kibana/config/kibana.yml \
+	&& grep -q 'elasticsearch:9200' /opt/kibana/config/kibana.yml
 
 ENV PATH /opt/kibana/bin:$PATH
 
-COPY ./docker-entrypoint.sh /
+COPY docker-entrypoint.sh /
 
 EXPOSE 5601
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/4.1/docker-entrypoint.sh
+++ b/4.1/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 # Add kibana as command if needed
@@ -9,16 +8,10 @@ fi
 
 # Run as user "kibana" if the command is "kibana"
 if [ "$1" = 'kibana' ]; then
-	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
-		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
+	if [ "$ELASTICSEARCH_URL" ]; then
 		sed -ri "s!^(\#\s*)?(elasticsearch_url:).*!\2 '$ELASTICSEARCH_URL'!" /opt/kibana/config/kibana.yml
-	else
-		echo >&2 'warning: missing ELASTICSEARCH_PORT_9200_TCP or ELASTICSEARCH_URL'
-		echo >&2 '  Did you forget to --link some-elasticsearch:elasticsearch'
-		echo >&2 '  or -e ELASTICSEARCH_URL=http://some-elasticsearch:9200 ?'
-		echo >&2
 	fi
-	
+
 	set -- gosu kibana tini -- "$@"
 fi
 

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -41,11 +41,15 @@ RUN set -x \
 	&& mkdir -p /opt/kibana \
 	&& tar -xz --strip-components=1 -C /opt/kibana -f kibana.tar.gz \
 	&& chown -R kibana:kibana /opt/kibana \
-	&& rm kibana.tar.gz
+	&& rm kibana.tar.gz \
+	\
+# ensure the default configuration is useful when using --link
+	&& sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 'http://elasticsearch:9200'!" /opt/kibana/config/kibana.yml \
+	&& grep -q 'elasticsearch:9200' /opt/kibana/config/kibana.yml
 
 ENV PATH /opt/kibana/bin:$PATH
 
-COPY ./docker-entrypoint.sh /
+COPY docker-entrypoint.sh /
 
 EXPOSE 5601
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/4.2/docker-entrypoint.sh
+++ b/4.2/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 # Add kibana as command if needed
@@ -9,16 +8,10 @@ fi
 
 # Run as user "kibana" if the command is "kibana"
 if [ "$1" = 'kibana' ]; then
-	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
-		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
+	if [ "$ELASTICSEARCH_URL" ]; then
 		sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 '$ELASTICSEARCH_URL'!" /opt/kibana/config/kibana.yml
-	else
-		echo >&2 'warning: missing ELASTICSEARCH_PORT_9200_TCP or ELASTICSEARCH_URL'
-		echo >&2 '  Did you forget to --link some-elasticsearch:elasticsearch'
-		echo >&2 '  or -e ELASTICSEARCH_URL=http://some-elasticsearch:9200 ?'
-		echo >&2
 	fi
-	
+
 	set -- gosu kibana tini -- "$@"
 fi
 

--- a/4.3/Dockerfile
+++ b/4.3/Dockerfile
@@ -41,11 +41,15 @@ RUN set -x \
 	&& mkdir -p /opt/kibana \
 	&& tar -xz --strip-components=1 -C /opt/kibana -f kibana.tar.gz \
 	&& chown -R kibana:kibana /opt/kibana \
-	&& rm kibana.tar.gz
+	&& rm kibana.tar.gz \
+	\
+# ensure the default configuration is useful when using --link
+	&& sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 'http://elasticsearch:9200'!" /opt/kibana/config/kibana.yml \
+	&& grep -q 'elasticsearch:9200' /opt/kibana/config/kibana.yml
 
 ENV PATH /opt/kibana/bin:$PATH
 
-COPY ./docker-entrypoint.sh /
+COPY docker-entrypoint.sh /
 
 EXPOSE 5601
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/4.3/docker-entrypoint.sh
+++ b/4.3/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 # Add kibana as command if needed
@@ -9,16 +8,10 @@ fi
 
 # Run as user "kibana" if the command is "kibana"
 if [ "$1" = 'kibana' ]; then
-	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
-		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
+	if [ "$ELASTICSEARCH_URL" ]; then
 		sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 '$ELASTICSEARCH_URL'!" /opt/kibana/config/kibana.yml
-	else
-		echo >&2 'warning: missing ELASTICSEARCH_PORT_9200_TCP or ELASTICSEARCH_URL'
-		echo >&2 '  Did you forget to --link some-elasticsearch:elasticsearch'
-		echo >&2 '  or -e ELASTICSEARCH_URL=http://some-elasticsearch:9200 ?'
-		echo >&2
 	fi
-	
+
 	set -- gosu kibana tini -- "$@"
 fi
 

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -45,7 +45,11 @@ RUN set -x \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends kibana=$KIBANA_VERSION \
 	&& chown -R kibana:kibana /opt/kibana \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+# ensure the default configuration is useful when using --link
+	&& sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 'http://elasticsearch:9200'!" /opt/kibana/config/kibana.yml \
+	&& grep -q 'elasticsearch:9200' /opt/kibana/config/kibana.yml
 
 ENV PATH /opt/kibana/bin:$PATH
 

--- a/4.4/docker-entrypoint.sh
+++ b/4.4/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 # Add kibana as command if needed
@@ -9,16 +8,10 @@ fi
 
 # Run as user "kibana" if the command is "kibana"
 if [ "$1" = 'kibana' ]; then
-	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
-		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
+	if [ "$ELASTICSEARCH_URL" ]; then
 		sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 '$ELASTICSEARCH_URL'!" /opt/kibana/config/kibana.yml
-	else
-		echo >&2 'warning: missing ELASTICSEARCH_PORT_9200_TCP or ELASTICSEARCH_URL'
-		echo >&2 '  Did you forget to --link some-elasticsearch:elasticsearch'
-		echo >&2 '  or -e ELASTICSEARCH_URL=http://some-elasticsearch:9200 ?'
-		echo >&2
 	fi
-	
+
 	set -- gosu kibana tini -- "$@"
 fi
 

--- a/4.5/Dockerfile
+++ b/4.5/Dockerfile
@@ -45,7 +45,11 @@ RUN set -x \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends kibana=$KIBANA_VERSION \
 	&& chown -R kibana:kibana /opt/kibana \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+# ensure the default configuration is useful when using --link
+	&& sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 'http://elasticsearch:9200'!" /opt/kibana/config/kibana.yml \
+	&& grep -q 'elasticsearch:9200' /opt/kibana/config/kibana.yml
 
 ENV PATH /opt/kibana/bin:$PATH
 

--- a/4.5/docker-entrypoint.sh
+++ b/4.5/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 # Add kibana as command if needed
@@ -9,16 +8,10 @@ fi
 
 # Run as user "kibana" if the command is "kibana"
 if [ "$1" = 'kibana' ]; then
-	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
-		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
+	if [ "$ELASTICSEARCH_URL" ]; then
 		sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 '$ELASTICSEARCH_URL'!" /opt/kibana/config/kibana.yml
-	else
-		echo >&2 'warning: missing ELASTICSEARCH_PORT_9200_TCP or ELASTICSEARCH_URL'
-		echo >&2 '  Did you forget to --link some-elasticsearch:elasticsearch'
-		echo >&2 '  or -e ELASTICSEARCH_URL=http://some-elasticsearch:9200 ?'
-		echo >&2
 	fi
-	
+
 	set -- gosu kibana tini -- "$@"
 fi
 

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -47,7 +47,11 @@ RUN set -x \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends kibana=$KIBANA_VERSION \
 	&& chown -R kibana:kibana /opt/kibana \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+# ensure the default configuration is useful when using --link
+	&& sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 'http://elasticsearch:9200'!" /opt/kibana/config/kibana.yml \
+	&& grep -q 'elasticsearch:9200' /opt/kibana/config/kibana.yml
 
 ENV PATH /opt/kibana/bin:$PATH
 

--- a/5.0/docker-entrypoint.sh
+++ b/5.0/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 # Add kibana as command if needed
@@ -9,16 +8,10 @@ fi
 
 # Run as user "kibana" if the command is "kibana"
 if [ "$1" = 'kibana' ]; then
-	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
-		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
+	if [ "$ELASTICSEARCH_URL" ]; then
 		sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 '$ELASTICSEARCH_URL'!" /opt/kibana/config/kibana.yml
-	else
-		echo >&2 'warning: missing ELASTICSEARCH_PORT_9200_TCP or ELASTICSEARCH_URL'
-		echo >&2 '  Did you forget to --link some-elasticsearch:elasticsearch'
-		echo >&2 '  or -e ELASTICSEARCH_URL=http://some-elasticsearch:9200 ?'
-		echo >&2
 	fi
-	
+
 	set -- gosu kibana tini -- "$@"
 fi
 


### PR DESCRIPTION
No longer rely on `--link` environment variables; default configuration assumes `elasticsearch` as a linked container (or same-network service), and `ELASTICSEARCH_URL` is still available for overriding that easily.
