### PR TITLE
Adjust "server.host" to be "0.0.0.0" explicitly in 5+ (the default has changed to "localhost")

### DIFF
--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -49,9 +49,13 @@ RUN set -x \
 	&& apt-get install -y --no-install-recommends kibana=$KIBANA_VERSION \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
+# the default "server.host" is "localhost" in 5+
+	&& sed -ri "s!^(\#\s*)?(server\.host:).*!\2 '0.0.0.0'!" /etc/kibana/kibana.yml \
+	&& grep -q "^server\.host: '0.0.0.0'\$" /etc/kibana/kibana.yml \
+	\
 # ensure the default configuration is useful when using --link
 	&& sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 'http://elasticsearch:9200'!" /etc/kibana/kibana.yml \
-	&& grep -q 'elasticsearch:9200' /etc/kibana/kibana.yml
+	&& grep -q "^elasticsearch\.url: 'http://elasticsearch:9200'\$" /etc/kibana/kibana.yml
 
 ENV PATH /usr/share/kibana/bin:$PATH
 


### PR DESCRIPTION
Closes #59
