### PR TITLE
Use "/etc/apt/trusted.gpg.d" instead of "apt-key adv"

### DIFF
--- a/4.6/Dockerfile
+++ b/4.6/Dockerfile
@@ -35,13 +35,19 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/tini \
 	&& tini -h
 
-# https://www.elastic.co/guide/en/kibana/4.4/setup.html#kibana-apt
-# https://packages.elasticsearch.org/GPG-KEY-elasticsearch
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+RUN set -ex; \
+# https://artifacts.elastic.co/GPG-KEY-elasticsearch
+	key='46095ACC8548582C1A2699A9D27D666CD88E42B4'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	gpg --export "$key" > /etc/apt/trusted.gpg.d/elastic.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 
 ENV KIBANA_MAJOR 4.6
 ENV KIBANA_VERSION 4.6.3
 
+# https://www.elastic.co/guide/en/kibana/4.4/setup.html#kibana-apt
 RUN echo "deb http://packages.elastic.co/kibana/${KIBANA_MAJOR}/debian stable main" > /etc/apt/sources.list.d/kibana.list
 
 RUN set -x \

--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -36,13 +36,19 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/tini \
 	&& tini -h
 
-# https://www.elastic.co/guide/en/kibana/5.0/deb.html
+RUN set -ex; \
 # https://artifacts.elastic.co/GPG-KEY-elasticsearch
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+	key='46095ACC8548582C1A2699A9D27D666CD88E42B4'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	gpg --export "$key" > /etc/apt/trusted.gpg.d/elastic.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
+
+# https://www.elastic.co/guide/en/kibana/5.0/deb.html
+RUN echo 'deb https://artifacts.elastic.co/packages/5.x/apt stable main' > /etc/apt/sources.list.d/kibana.list
 
 ENV KIBANA_VERSION 5.1.1
-
-RUN echo 'deb https://artifacts.elastic.co/packages/5.x/apt stable main' > /etc/apt/sources.list.d/kibana.list
 
 RUN set -x \
 	&& apt-get update \


### PR DESCRIPTION
> Note: Instead of using this command a keyring should be placed
> directly in the /etc/apt/trusted.gpg.d/ directory with a
> descriptive name and either "gpg" or "asc" as file extension.

https://manpages.debian.org/cgi-bin/man.cgi?query=apt-key&manpath=Debian+testing+stretch

See also docker-library/cassandra#91, docker-library/mariadb#93, docker-library/mongo#132, docker-library/mysql#254, docker-library/percona#39, docker-library/postgres#246, docker-library/elasticsearch#152, and https://github.com/docker-library/logstash/pull/78.