### PR TITLE
Ignore "created"/"build-date" when calculating image history

### DIFF
--- a/.github/workflows/history.sh
+++ b/.github/workflows/history.sh
@@ -6,19 +6,18 @@ set -Eeuo pipefail
 docker image history --no-trunc --format '{{ .CreatedBy }}' "$@" \
 	| tac \
 	| sed -r 's!^/bin/sh[[:space:]]+-c[[:space:]]+(#[(]nop[)][[:space:]]+)?!!' \
-	| awk '
-		# ignore the first ADD of the base image (base image changes unnecessarily break our diffs)
-		NR == 1 && $1 == "ADD" && $4 == "/" { next }
-		# TODO consider instead just removing the checksum in $3
-
-		# ignore obviously "centos" LABEL instructions (include a timestamp, so base image changes unnecessarily break our diffs)
-		$1 == "LABEL" && / org.opencontainers.image.vendor=CentOS | org.label-schema.vendor=CentOS / { next }
+	| gawk '
+		# munge the checksum of the first ADD of the base image (base image changes unnecessarily break our diffs)
+		NR == 1 && $1 == "ADD" && $4 == "/" { $2 = "-" }
 
 		# just ignore the default CentOS CMD value (not relevant to our needs)
 		$0 == "CMD [\"/bin/bash\"]" { next }
 
 		# ignore the contents of certain copies (notoriously unreliable hashes because they often contain timestamps)
 		$1 == "COPY" && $4 == "/usr/share/kibana/config/kibana.yml" { gsub(/:[0-9a-f]{64}$/, ":filtered-content-hash", $2) }
+
+		# remove "org.label-schema.build-date" and "org.opencontainers.image.created" (https://github.com/elastic/dockerfiles/pull/101#pullrequestreview-879623350)
+		$1 == "LABEL" { gsub(/ (org[.]label-schema[.]build-date|org[.]opencontainers[.]image[.]created)=[^ ]+( [0-9:+-]+)?/, "") }
 
 		# sane and sanitized, print it!
 		{ print }


### PR DESCRIPTION
https://github.com/elastic/dockerfiles/pull/101#pullrequestreview-879623350 (which has recurred on 8.0.1)