### PR TITLE
Temporary backfill of missed versions

### DIFF
--- a/7.17.11/Dockerfile
+++ b/7.17.11/Dockerfile
@@ -1,0 +1,17 @@
+# Kibana 7.17.11
+
+# This image re-bundles the Docker image from the upstream provider, Elastic.
+FROM docker.elastic.co/kibana/kibana:7.17.11@sha256:c18221ec6c140acc9229c44e8fb85b0627b996c4cafd0adb06767a794541905d
+# Supported Bashbrew Architectures: amd64 arm64v8
+
+# The upstream image was built by:
+#   https://github.com/elastic/dockerfiles/tree/v7.17.11/kibana
+
+# The build can be reproduced locally via:
+#   docker build 'https://github.com/elastic/dockerfiles.git#v7.17.11:kibana'
+
+# For a full list of supported images and tags visit https://www.docker.elastic.co
+
+# For documentation visit https://www.elastic.co/guide/en/kibana/current/docker.html
+
+# See https://github.com/docker-library/official-images/pull/4917 for more details.

--- a/8.8.2/Dockerfile
+++ b/8.8.2/Dockerfile
@@ -1,0 +1,17 @@
+# Kibana 8.8.2
+
+# This image re-bundles the Docker image from the upstream provider, Elastic.
+FROM docker.elastic.co/kibana/kibana:8.8.2@sha256:f7d62957d7a831209e873bf99ded2c2f9cddcbde3acac3071fe42e318b6911af
+# Supported Bashbrew Architectures: amd64 arm64v8
+
+# The upstream image was built by:
+#   https://github.com/elastic/dockerfiles/tree/v8.8.2/kibana
+
+# The build can be reproduced locally via:
+#   docker build 'https://github.com/elastic/dockerfiles.git#v8.8.2:kibana'
+
+# For a full list of supported images and tags visit https://www.docker.elastic.co
+
+# For documentation visit https://www.elastic.co/guide/en/kibana/current/docker.html
+
+# See https://github.com/docker-library/official-images/pull/4917 for more details.

--- a/8.9.0/Dockerfile
+++ b/8.9.0/Dockerfile
@@ -1,0 +1,17 @@
+# Kibana 8.9.0
+
+# This image re-bundles the Docker image from the upstream provider, Elastic.
+FROM docker.elastic.co/kibana/kibana:8.9.0@sha256:300a3b4a9093a4468bcc156c786cd2f7d58da973959b72ab1d29d34b838e3431
+# Supported Bashbrew Architectures: amd64 arm64v8
+
+# The upstream image was built by:
+#   https://github.com/elastic/dockerfiles/tree/v8.9.0/kibana
+
+# The build can be reproduced locally via:
+#   docker build 'https://github.com/elastic/dockerfiles.git#v8.9.0:kibana'
+
+# For a full list of supported images and tags visit https://www.docker.elastic.co
+
+# For documentation visit https://www.elastic.co/guide/en/kibana/current/docker.html
+
+# See https://github.com/docker-library/official-images/pull/4917 for more details.

--- a/update.sh
+++ b/update.sh
@@ -29,7 +29,7 @@ for version in "${versions[@]}"; do
 	fi
 
 	fullVersion="$(
-		grep -P "^\Qv$rcVersion." <<<"$tags" \
+		grep -P "^\Qv$rcVersion" <<<"$tags" \
 			| grep $rcGrepV -E -- '-(alpha|beta|rc)' \
 			| tail -1
 	)"


### PR DESCRIPTION
This is just to fill in `7.17.11`, `8.8.2`, and `8.9.0`.

Once merged, we can open the revert PR immediately. Once the changes are referenced in `docker-library/official-images` we can merge the revert.

```diff
$ diff -u ../official-images/library/kibana <(./generate-stackbrew-library.sh)
--- ../official-images/library/kibana   2023-08-23 16:05:44.440405336 -0700
+++ /dev/fd/63  2023-08-23 16:07:06.874993258 -0700
@@ -4,11 +4,26 @@
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git

+Tags: 8.9.0
+Architectures: amd64, arm64v8
+GitCommit: 52950fea8dd5b2466d327f62b4e6a7d8bbb0f865
+Directory: 8.9.0
+
+Tags: 8.8.2
+Architectures: amd64, arm64v8
+GitCommit: 52950fea8dd5b2466d327f62b4e6a7d8bbb0f865
+Directory: 8.8.2
+
 Tags: 8.9.1
 Architectures: amd64, arm64v8
 GitCommit: bc464499de24fd857521ba25fcb8d58f23516d3d
 Directory: 8

+Tags: 7.17.11
+Architectures: amd64, arm64v8
+GitCommit: 52950fea8dd5b2466d327f62b4e6a7d8bbb0f865
+Directory: 7.17.11
+
 Tags: 7.17.12
 Architectures: amd64, arm64v8
 GitCommit: c2cb4e05003784aaa811f1c2ec8df9bdfb8d46e5
```

related to https://github.com/docker-library/elasticsearch/pull/208 and https://github.com/docker-library/logstash/pull/106